### PR TITLE
Update deps and stabilize tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ typings/
 .env
 
 yarn.lock
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -10,22 +10,22 @@
   "scripts": {
     "lint": "aegir lint",
     "build": "aegir build",
-    "test": "aegir test",
-    "test:node": "aegir test -t node",
+    "test": "aegir test -f test/**/*.spec.js",
+    "test:node": "aegir test -t node -f test/**/*.spec.js",
     "release": "aegir release",
     "release-minor": "aegir release --type minor",
     "release-major": "aegir release --type major",
     "coverage": "aegir coverage"
   },
   "devDependencies": {
-    "aegir": "^13.0.7",
-    "async": "^2.6.0",
+    "aegir": "^15.0.1",
+    "async": "^2.6.1",
     "chai": "^4.1.2",
-    "go-ipfs-dep": "^0.4.14",
-    "ipfsd-ctl": "^0.32.1"
+    "go-ipfs-dep": "~0.4.16",
+    "ipfsd-ctl": "~0.38.0"
   },
   "dependencies": {
-    "ipfs-api": "^20.0.1",
-    "peer-info": "^0.14.1"
+    "ipfs-api": "^22.2.4",
+    "peer-info": "~0.14.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const peerNotFoundError = (id) => {
 
 class DelegatedPeerRouting {
   constructor (api) {
-    this.api = Object.assign({}, defaultConfig(), api || DEFAULT_IPFS_API)
+    this.api = Object.assign({}, defaultConfig(), DEFAULT_IPFS_API, api)
     this.dht = dht(this.api)
   }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -38,8 +38,8 @@ function spawnNode (boostrap, callback) {
 describe('DelegatedPeerRouting', function () {
   this.timeout(20 * 1000) // we're spawning daemons, give ci some time
 
-  let selfNode
-  let selfId
+  let nodeToFind
+  let peerIdToFind
   let delegatedNode
   let bootstrapNode
   let bootstrapId
@@ -56,8 +56,8 @@ describe('DelegatedPeerRouting', function () {
       // Spawn our local node and bootstrap the bootstrapper node
       (cb) => spawnNode(bootstrapId.addresses, cb),
       (ipfsd, id, cb) => {
-        selfNode = ipfsd
-        selfId = id
+        nodeToFind = ipfsd
+        peerIdToFind = id
         cb()
       },
       // Spawn the delegate node and bootstrap the bootstrapper node
@@ -71,7 +71,7 @@ describe('DelegatedPeerRouting', function () {
 
   after((done) => {
     async.parallel([
-      (cb) => selfNode.stop(cb),
+      (cb) => nodeToFind.stop(cb),
       (cb) => delegatedNode.stop(cb),
       (cb) => bootstrapNode.stop(cb)
     ], done)
@@ -124,9 +124,9 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       })
 
-      router.findPeer(selfId.id, (err, peer) => {
+      router.findPeer(peerIdToFind.id, (err, peer) => {
         expect(err).to.equal(null)
-        expect(peer.id).to.eql(selfId.id)
+        expect(peer.id).to.eql(peerIdToFind.id)
         done()
       })
     })


### PR DESCRIPTION
Tests should be stable now as they have been updated to isolate the nodes in test so we don't get indeterministic behavior from hitting public nodes.