### PR TITLE
fix: better support for peer ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ jspm_packages/
 # Typescript v1 declaration files
 typings/
 
+# Documentation
+docs
+
 # Optional npm cache directory
 .npm
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "ipfs-api": "^24.0.1",
+    "peer-id": "~0.11.0",
     "peer-info": "~0.14.1"
   },
   "contributors": [

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const PeerInfo = require('peer-info')
+const PeerId = require('peer-id')
 const dht = require('ipfs-api/src/dht')
 const defaultConfig = require('ipfs-api/src/utils/default-config')
 
@@ -20,7 +21,18 @@ class DelegatedPeerRouting {
     this.dht = dht(this.api)
   }
 
+  /**
+   * Attempts to find the given peer
+   *
+   * @param {PeerID} id
+   * @param {function(Error, PeerInfo)} callback
+   * @returns {void}
+   */
   findPeer (id, callback) {
+    if (typeof id !== 'string') {
+      id = id.toB58String()
+    }
+
     this.dht.findpeer(id, (err, results) => {
       if (err) {
         return callback(err)
@@ -38,7 +50,9 @@ class DelegatedPeerRouting {
         return callback(peerNotFoundError(id))
       }
       const details = wantedResponse.Responses[0]
-      const info = new PeerInfo(details.ID)
+      const info = new PeerInfo(
+        PeerId.createFromB58String(details.ID)
+      )
       details.Addrs.forEach((addr) => info.multiaddrs.add(addr))
 
       // there should be only one of these

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ class DelegatedPeerRouting {
    * @returns {void}
    */
   findPeer (id, callback) {
-    if (typeof id !== 'string') {
+    if (PeerId.isPeerId(id)) {
       id = id.toB58String()
     }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,6 +4,7 @@
 const expect = require('chai').expect
 const IPFSFactory = require('ipfsd-ctl')
 const async = require('async')
+const PeerID = require('peer-id')
 
 const DelegatedPeerRouting = require('../src')
 const factory = IPFSFactory.create({ type: 'go' })
@@ -116,7 +117,7 @@ describe('DelegatedPeerRouting', function () {
   })
 
   describe('findPeers', () => {
-    it('should be able to find peers via the delegate', (done) => {
+    it('should be able to find peers via the delegate with a peer id string', (done) => {
       const opts = delegatedNode.apiAddr.toOptions()
       const router = new DelegatedPeerRouting({
         protocol: 'http',
@@ -125,6 +126,21 @@ describe('DelegatedPeerRouting', function () {
       })
 
       router.findPeer(peerIdToFind.id, (err, peer) => {
+        expect(err).to.equal(null)
+        expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
+        done()
+      })
+    })
+
+    it('should be able to find peers via the delegate with a peerid', (done) => {
+      const opts = delegatedNode.apiAddr.toOptions()
+      const router = new DelegatedPeerRouting({
+        protocol: 'http',
+        port: opts.port,
+        host: opts.host
+      })
+
+      router.findPeer(PeerID.createFromB58String(peerIdToFind.id), (err, peer) => {
         expect(err).to.equal(null)
         expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
         done()

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -126,7 +126,7 @@ describe('DelegatedPeerRouting', function () {
 
       router.findPeer(peerIdToFind.id, (err, peer) => {
         expect(err).to.equal(null)
-        expect(peer.id).to.eql(peerIdToFind.id)
+        expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
         done()
       })
     })


### PR DESCRIPTION
After working on an example I ran into some inconsistency issues with peer ids not being proper ids. 

This PR improves the consistency in which PeerIDs are used. 