### PR TITLE
feat: add timeout defaults

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,24 +26,31 @@ class DelegatedPeerRouting {
    * Attempts to find the given peer
    *
    * @param {PeerID} id
-   * @param {number} timeout How long the query can take. Defaults to 30 seconds
+   * @param {object} options
+   * @param {number} options.maxTimeout How long the query can take. Defaults to 30 seconds
    * @param {function(Error, PeerInfo)} callback
    * @returns {void}
    */
-  findPeer (id, timeout, callback) {
-    if (typeof timeout === 'function') {
-      callback = timeout
-      timeout = null
+  findPeer (id, options, callback) {
+    if (typeof options === 'function') {
+      callback = options
+      options = {}
+    } else if (typeof options === 'number') { // This will be deprecated in a next release
+      options = {
+        maxTimeout: options
+      }
+    } else {
+      options = options || {}
     }
 
     if (PeerId.isPeerId(id)) {
       id = id.toB58String()
     }
 
-    timeout = timeout || DEFAULT_MAX_TIMEOUT
+    options.maxTimeout = options.maxTimeout || DEFAULT_MAX_TIMEOUT
 
     this.dht.findpeer(id, {
-      timeout: `${timeout}ms`// The api requires specification of the time unit (s/ms)
+      timeout: `${options.maxTimeout}ms`// The api requires specification of the time unit (s/ms)
     }, (err, results) => {
       if (err) {
         return callback(err)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -147,6 +147,21 @@ describe('DelegatedPeerRouting', function () {
       })
     })
 
+    it('should be able to specify a timeout', (done) => {
+      const opts = delegatedNode.apiAddr.toOptions()
+      const router = new DelegatedPeerRouting({
+        protocol: 'http',
+        port: opts.port,
+        host: opts.host
+      })
+
+      router.findPeer(PeerID.createFromB58String(peerIdToFind.id), 2000, (err, peer) => {
+        expect(err).to.equal(null)
+        expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
+        done()
+      })
+    })
+
     it('should not be able to find peers not on the network', (done) => {
       const opts = delegatedNode.apiAddr.toOptions()
       const router = new DelegatedPeerRouting({

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -147,7 +147,7 @@ describe('DelegatedPeerRouting', function () {
       })
     })
 
-    it('should be able to specify a timeout', (done) => {
+    it('should be able to specify a maxTimeout', (done) => {
       const opts = delegatedNode.apiAddr.toOptions()
       const router = new DelegatedPeerRouting({
         protocol: 'http',
@@ -155,7 +155,7 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       })
 
-      router.findPeer(PeerID.createFromB58String(peerIdToFind.id), 2000, (err, peer) => {
+      router.findPeer(PeerID.createFromB58String(peerIdToFind.id), { maxTimeout: 2000 }, (err, peer) => {
         expect(err).to.equal(null)
         expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
         done()


### PR DESCRIPTION
The PR aims to mitigate an issue where connections to the delegate node would stay open for an extended period. This change will pass the `timeout` param to the API allowing for better limiting.

* Adds the timeout param to `findPeer`, which is compatible with the kad dht. This also sets a default limit of 30 seconds to limit the http calls to the delegate. 

Reference: https://github.com/ipfs/go-ipfs/pull/4595#issuecomment-420927609


I have verified this using the [WIP libp2p implementation](https://github.com/libp2p/js-libp2p/pull/242) and a local go-ipfs delegate node. 