### PR TITLE
feat: refactor to use async/await

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -6,7 +6,9 @@ const server = createServer()
 
 module.exports = {
   hooks: {
-    pre: server.start.bind(server),
-    post: server.stop.bind(server)
+    browser: {
+      pre: () => server.start(),
+      post: () => server.stop()
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ const DelegatedPeerRouting = require('libp2p-delegated-routing')
 // default is to use ipfs.io
 const routing = new DelegatedPeerRouing()
 
-routing.findPeer('peerid', (err, peerInfo) => {
-  if (err) {
-    return console.error(err)
-  }
+try {
+  const peerInfo = await routing.findPeer('peerid')
 
   console.log('found peer details', peerInfo)
-})
+} catch (err) {
+  console.error(err)
+}
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -18,17 +18,15 @@
     "coverage": "aegir coverage"
   },
   "devDependencies": {
-    "aegir": "^19.0.5",
-    "async": "^3.1.0",
+    "aegir": "^19.0.4",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "go-ipfs-dep": "^0.4.21",
-    "ipfsd-ctl": "^0.43.0"
+    "go-ipfs-dep": "~0.4.17",
+    "ipfsd-ctl": "^0.44.1"
   },
   "dependencies": {
-    "ipfs-http-client": "^33.0.1",
-    "peer-id": "^0.12.2",
-    "peer-info": "^0.15.1"
+    "ipfs-http-client": "^33.1.0",
+    "peer-id": "~0.12.2"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/src/index.js
+++ b/src/index.js
@@ -23,39 +23,26 @@ class DelegatedPeerRouting {
    * @param {PeerID} id
    * @param {object} options
    * @param {number} options.maxTimeout How long the query can take. Defaults to 30 seconds
-   * @param {function(Error, PeerInfo)} callback
-   * @returns {void}
+   * @returns {Promise<PeerInfo>}
    */
-  findPeer (id, options, callback) {
-    if (typeof options === 'function') {
-      callback = options
-      options = {}
-    } else if (typeof options === 'number') { // This will be deprecated in a next release
-      options = {
-        maxTimeout: options
-      }
-    } else {
-      options = options || {}
-    }
-
+  async findPeer (id, options = {}) {
     if (PeerId.isPeerId(id)) {
       id = id.toB58String()
     }
 
     options.maxTimeout = options.maxTimeout || DEFAULT_MAX_TIMEOUT
 
-    this.dht.findPeer(id, {
-      timeout: `${options.maxTimeout}ms`// The api requires specification of the time unit (s/ms)
-    }, (err, info) => {
-      if (err) {
-        if (err.message.includes('not found')) {
-          return callback()
-        }
-        return callback(err)
+    try {
+      return await this.dht.findPeer(id, {
+        timeout: `${options.maxTimeout}ms`// The api requires specification of the time unit (s/ms)
+      })
+    } catch (err) {
+      if (err.message.includes('not found')) {
+        return undefined
       }
 
-      callback(null, info)
-    })
+      throw err
+    }
   }
 }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,19 +5,13 @@ const chai = require('chai')
 const { expect } = chai
 chai.use(require('dirty-chai'))
 const IPFSFactory = require('ipfsd-ctl')
-const async = require('async')
 const PeerID = require('peer-id')
 
 const DelegatedPeerRouting = require('../src')
 const factory = IPFSFactory.create({ type: 'go' })
 
-function spawnNode (boostrap, callback) {
-  if (typeof boostrap === 'function') {
-    callback = boostrap
-    boostrap = []
-  }
-
-  factory.spawn({
+async function spawnNode (boostrap = []) {
+  const node = await factory.spawn({
     // Lock down the nodes so testing can be deterministic
     config: {
       Bootstrap: boostrap,
@@ -27,15 +21,13 @@ function spawnNode (boostrap, callback) {
         }
       }
     }
-  }, (err, node) => {
-    if (err) return callback(err)
-
-    node.api.id((err, id) => {
-      if (err) return callback(err)
-
-      callback(null, node, id)
-    })
   })
+  const id = await node.api.id()
+
+  return {
+    node,
+    id
+  }
 }
 
 describe('DelegatedPeerRouting', function () {
@@ -47,37 +39,28 @@ describe('DelegatedPeerRouting', function () {
   let bootstrapNode
   let bootstrapId
 
-  before((done) => {
-    async.waterfall([
-      // Spawn a "Boostrap" node that doesnt connect to anything
-      (cb) => spawnNode(cb),
-      (ipfsd, id, cb) => {
-        bootstrapNode = ipfsd
-        bootstrapId = id
-        cb()
-      },
-      // Spawn our local node and bootstrap the bootstrapper node
-      (cb) => spawnNode(bootstrapId.addresses, cb),
-      (ipfsd, id, cb) => {
-        nodeToFind = ipfsd
-        peerIdToFind = id
-        cb()
-      },
-      // Spawn the delegate node and bootstrap the bootstrapper node
-      (cb) => spawnNode(bootstrapId.addresses, cb),
-      (ipfsd, id, cb) => {
-        delegatedNode = ipfsd
-        cb()
-      }
-    ], done)
+  before(async () => {
+    // Spawn a "Boostrap" node that doesnt connect to anything
+    const bootstrap = await spawnNode()
+    bootstrapNode = bootstrap.node
+    bootstrapId = bootstrap.id
+
+    // Spawn our local node and bootstrap the bootstrapper node
+    const local = await spawnNode(bootstrapId.addresses)
+    nodeToFind = local.node
+    peerIdToFind = local.id
+
+    // Spawn the delegate node and bootstrap the bootstrapper node
+    const delegate = await spawnNode(bootstrapId.addresses)
+    delegatedNode = delegate.node
   })
 
-  after((done) => {
-    async.parallel([
-      (cb) => nodeToFind.stop(cb),
-      (cb) => delegatedNode.stop(cb),
-      (cb) => bootstrapNode.stop(cb)
-    ], done)
+  after(() => {
+    return Promise.all([
+      nodeToFind.stop(),
+      delegatedNode.stop(),
+      bootstrapNode.stop()
+    ])
   })
 
   describe('create', () => {
@@ -119,7 +102,7 @@ describe('DelegatedPeerRouting', function () {
   })
 
   describe('findPeers', () => {
-    it('should be able to find peers via the delegate with a peer id string', (done) => {
+    it('should be able to find peers via the delegate with a peer id string', async () => {
       const opts = delegatedNode.apiAddr.toOptions()
       const router = new DelegatedPeerRouting({
         protocol: 'http',
@@ -127,15 +110,12 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       })
 
-      router.findPeer(peerIdToFind.id, (err, peer) => {
-        expect(err).to.not.exist()
-        expect(peer).to.exist()
-        expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
-        done()
-      })
+      const peer = await router.findPeer(peerIdToFind.id)
+      expect(peer).to.exist()
+      expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
     })
 
-    it('should be able to find peers via the delegate with a peerid', (done) => {
+    it('should be able to find peers via the delegate with a peerid', async () => {
       const opts = delegatedNode.apiAddr.toOptions()
       const router = new DelegatedPeerRouting({
         protocol: 'http',
@@ -143,15 +123,12 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       })
 
-      router.findPeer(PeerID.createFromB58String(peerIdToFind.id), (err, peer) => {
-        expect(err).to.not.exist()
-        expect(peer).to.exist()
-        expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
-        done()
-      })
+      const peer = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id))
+      expect(peer).to.exist()
+      expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
     })
 
-    it('should be able to specify a maxTimeout', (done) => {
+    it('should be able to specify a maxTimeout', async () => {
       const opts = delegatedNode.apiAddr.toOptions()
       const router = new DelegatedPeerRouting({
         protocol: 'http',
@@ -159,15 +136,12 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       })
 
-      router.findPeer(PeerID.createFromB58String(peerIdToFind.id), { maxTimeout: 2000 }, (err, peer) => {
-        expect(err).to.not.exist()
-        expect(peer).to.exist()
-        expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
-        done()
-      })
+      const peer = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id), { maxTimeout: 2000 })
+      expect(peer).to.exist()
+      expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
     })
 
-    it('should not be able to find peers not on the network', (done) => {
+    it('should not be able to find peers not on the network', async () => {
       const opts = delegatedNode.apiAddr.toOptions()
       const router = new DelegatedPeerRouting({
         protocol: 'http',
@@ -177,11 +151,8 @@ describe('DelegatedPeerRouting', function () {
 
       // This is one of the default Bootstrap nodes, but we're not connected to it
       // so we'll test with it.
-      router.findPeer('QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64', (err, peer) => {
-        expect(err).to.not.exist()
-        expect(peer).to.not.exist()
-        done()
-      })
+      const peer = await router.findPeer('QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64')
+      expect(peer).to.not.exist()
     })
   })
 })


### PR DESCRIPTION
Also upgrades all the deps, moves from `ipfs-api` to `ipfs-http-client` and removes a lot of results massaging that is now done in the http client.