### PR TITLE
chore: use travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: node_js
+cache: npm
+stages:
+  - check
+  - test
+  - cov
+
+node_js:
+  - '10'
+  - '12'
+
+os:
+  - linux
+  - osx
+
+script: npx nyc -s npm run test:node -- --bail
+after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
+
+jobs:
+  include:
+    - os: windows
+      cache: false
+
+    - stage: check
+      script:
+        - npx aegir dep-check
+        - npm run lint
+
+    - stage: test
+      name: chrome
+      addons:
+        chrome: stable
+      script: npx aegir test -t browser -t webworker
+
+    - stage: test
+      name: firefox
+      addons:
+        firefox: latest
+      script: npx aegir test -t browser -t webworker -- --browsers FirefoxHeadless
+
+notifications:
+  email: false

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,1 +1,0 @@
-javascript()


### PR DESCRIPTION
This **just** moves CI over to travis since jenkins is no longer available. CI is going to fail for this, but that will get fixed in a subsequent PR. Since there is an async/await PR in progress I wanted to avoid conflicts for that, and avoid tacking this onto that PR.