### PR TITLE
chore: rename timeout option

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,17 +18,17 @@
     "coverage": "aegir coverage"
   },
   "devDependencies": {
-    "aegir": "^19.0.4",
+    "aegir": "^20.4.1",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "go-ipfs-dep": "~0.4.17",
+    "go-ipfs-dep": "~0.4.22",
     "ipfsd-ctl": "^0.44.1"
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "ipfs-http-client": "^33.1.0",
-    "p-queue": "^6.1.0",
-    "peer-id": "~0.12.2"
+    "ipfs-http-client": "^40.0.1",
+    "p-queue": "^6.2.1",
+    "peer-id": "~0.13.5"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/src/index.js
+++ b/src/index.js
@@ -2,14 +2,14 @@
 
 const PeerId = require('peer-id')
 const dht = require('ipfs-http-client/src/dht')
-const defaultConfig = require('ipfs-http-client/src/utils/default-config')
+const getEndpointConfig = require('ipfs-http-client/src/get-endpoint-config')
 const { default: PQueue } = require('p-queue')
 const debug = require('debug')
 
 const log = debug('libp2p-delegated-peer-routing')
 log.error = debug('libp2p-delegated-peer-routing:error')
 
-const DEFAULT_MAX_TIMEOUT = 30e3 // 30 second default
+const DEFAULT_TIMEOUT = 30e3 // 30 second default
 const DEFAULT_IPFS_API = {
   protocol: 'https',
   port: 443,
@@ -19,7 +19,7 @@ const CONCURRENT_HTTP_REQUESTS = 4
 
 class DelegatedPeerRouting {
   constructor (api) {
-    this.api = Object.assign({}, defaultConfig(), DEFAULT_IPFS_API, api)
+    this.api = Object.assign({}, getEndpointConfig()(), DEFAULT_IPFS_API, api)
     this.dht = dht(this.api)
 
     // limit concurrency to avoid request flood in web browser
@@ -35,7 +35,7 @@ class DelegatedPeerRouting {
    *
    * @param {PeerID} id
    * @param {object} options
-   * @param {number} options.maxTimeout How long the query can take. Defaults to 30 seconds
+   * @param {number} options.timeout How long the query can take. Defaults to 30 seconds
    * @returns {Promise<PeerInfo>}
    */
   async findPeer (id, options = {}) {
@@ -44,11 +44,11 @@ class DelegatedPeerRouting {
     }
     log('findPeer starts: ' + id)
 
-    options.maxTimeout = options.maxTimeout || DEFAULT_MAX_TIMEOUT
+    options.timeout = options.timeout || DEFAULT_TIMEOUT
 
     try {
       return await this._httpQueue.add(() => this.dht.findPeer(id, {
-        timeout: `${options.maxTimeout}ms`// The api requires specification of the time unit (s/ms)
+        timeout: `${options.timeout}ms`// The api requires specification of the time unit (s/ms)
       }))
     } catch (err) {
       if (err.message.includes('not found')) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -68,7 +68,7 @@ describe('DelegatedPeerRouting', function () {
       const router = new DelegatedPeerRouting()
 
       expect(router.api).to.include({
-        'api-path': '/api/v0/',
+        'api-path': '/api/v0',
         protocol: 'https',
         port: 443,
         host: 'node0.delegate.ipfs.io'
@@ -81,7 +81,7 @@ describe('DelegatedPeerRouting', function () {
       })
 
       expect(router.api).to.include({
-        'api-path': '/api/v0/',
+        'api-path': '/api/v0',
         protocol: 'https',
         port: 443,
         host: 'other.ipfs.io'
@@ -90,7 +90,7 @@ describe('DelegatedPeerRouting', function () {
 
     it('should allow for overriding the api', () => {
       const api = {
-        'api-path': '/api/v1/',
+        'api-path': '/api/v1',
         protocol: 'http',
         port: 8000,
         host: 'localhost'
@@ -128,7 +128,7 @@ describe('DelegatedPeerRouting', function () {
       expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
     })
 
-    it('should be able to specify a maxTimeout', async () => {
+    it('should be able to specify a timeout', async () => {
       const opts = delegatedNode.apiAddr.toOptions()
       const router = new DelegatedPeerRouting({
         protocol: 'http',
@@ -136,7 +136,7 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       })
 
-      const peer = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id), { maxTimeout: 2000 })
+      const peer = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id), { timeout: 2000 })
       expect(peer).to.exist()
       expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
     })


### PR DESCRIPTION
This PR renames timeout option to be consistent with the `libp2p-kad-dht` implementation, in order to both be used in the `libp2p` routers.

Other than that, dependencies were updated

BREAKING CHANGE: maxTimeout option renamed to timeout