### PR TITLE
chore/remove-peer-info-from-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ const DelegatedPeerRouting = require('libp2p-delegated-peer-routing')
 const routing = new DelegatedPeerRouing()
 
 try {
-  const { id, addresses } = await routing.findPeer('peerid')
+  const { id, multiaddrs } = await routing.findPeer('peerid')
 
-  console.log('found peer details', id, addresses)
+  console.log('found peer details', id, multiaddrs)
 } catch (err) {
   console.error(err)
 }

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ const DelegatedPeerRouting = require('libp2p-delegated-peer-routing')
 const routing = new DelegatedPeerRouing()
 
 try {
-  const peerInfo = await routing.findPeer('peerid')
+  const { id, addresses } = await routing.findPeer('peerid')
 
-  console.log('found peer details', peerInfo)
+  console.log('found peer details', id, addresses)
 } catch (err) {
   console.error(err)
 }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "debug": "^4.1.1",
     "ipfs-http-client": "^44.0.0",
     "p-queue": "^6.3.0",
-    "peer-id": "^0.13.11",
-    "peer-info": "^0.17.5"
+    "peer-id": "^0.13.11"
   },
   "contributors": [
     "Jacob Heun <jacobheun@gmail.com>",

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ class DelegatedPeerRouting {
    * @param {PeerID} id
    * @param {object} options
    * @param {number} options.timeout How long the query can take. Defaults to 30 seconds
-   * @returns {Promise<{ id: PeerId, addrs: Multiaddr[] }>}
+   * @returns {Promise<{ id: PeerId, multiaddrs: Multiaddr[] }>}
    */
   async findPeer (id, options = {}) {
     let idStr = id
@@ -55,7 +55,7 @@ class DelegatedPeerRouting {
 
         return {
           id,
-          addrs
+          multiaddrs: addrs
         }
       })
     } catch (err) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -111,15 +111,17 @@ describe('DelegatedPeerRouting', function () {
   describe('findPeers', () => {
     it('should be able to find peers via the delegate with a peer id string', async () => {
       const opts = delegatedNode.apiAddr.toOptions()
+
       const router = new DelegatedPeerRouting({
         protocol: 'http',
         port: opts.port,
         host: opts.host
       })
 
-      const peer = await router.findPeer(peerIdToFind.id)
-      expect(peer).to.exist()
-      expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
+      const { id, addrs } = await router.findPeer(peerIdToFind.id)
+      expect(id).to.exist()
+      expect(addrs).to.exist()
+      expect(id).to.eql(peerIdToFind.id)
     })
 
     it('should be able to find peers via the delegate with a peerid', async () => {
@@ -130,9 +132,11 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       })
 
-      const peer = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id))
-      expect(peer).to.exist()
-      expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
+      const { id, addrs } = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id))
+      expect(id).to.exist()
+      expect(addrs).to.exist()
+
+      expect(id.toB58String()).to.eql(peerIdToFind.id)
     })
 
     it('should be able to specify a timeout', async () => {
@@ -143,9 +147,11 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       })
 
-      const peer = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id), { timeout: 2000 })
-      expect(peer).to.exist()
-      expect(peer.id.toB58String()).to.eql(peerIdToFind.id)
+      const { id, addrs } = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id), { timeout: 2000 })
+      expect(id).to.exist()
+      expect(addrs).to.exist()
+
+      expect(id.toB58String()).to.eql(peerIdToFind.id)
     })
 
     it('should not be able to find peers not on the network', async () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -118,9 +118,9 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       })
 
-      const { id, addrs } = await router.findPeer(peerIdToFind.id)
+      const { id, multiaddrs } = await router.findPeer(peerIdToFind.id)
       expect(id).to.exist()
-      expect(addrs).to.exist()
+      expect(multiaddrs).to.exist()
       expect(id).to.eql(peerIdToFind.id)
     })
 
@@ -132,9 +132,9 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       })
 
-      const { id, addrs } = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id))
+      const { id, multiaddrs } = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id))
       expect(id).to.exist()
-      expect(addrs).to.exist()
+      expect(multiaddrs).to.exist()
 
       expect(id.toB58String()).to.eql(peerIdToFind.id)
     })
@@ -147,9 +147,9 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       })
 
-      const { id, addrs } = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id), { timeout: 2000 })
+      const { id, multiaddrs } = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id), { timeout: 2000 })
       expect(id).to.exist()
-      expect(addrs).to.exist()
+      expect(multiaddrs).to.exist()
 
       expect(id.toB58String()).to.eql(peerIdToFind.id)
     })


### PR DESCRIPTION
In the context of deprecating `peer-info` as described on [libp2p/js-libp2p#589](https://github.com/libp2p/js-libp2p/issues/589), this PR removes the `peer-info` from being returned in the API, in favour of returning `{ id, addrs }` in the same way as [ipfs](https://github.com/ipfs/js-ipfs/blob/447b44d1b64714f5ed0cafba166ad0a4dbbb587c/packages/ipfs/src/core/components/dht.js#L61) does.


BREAKING CHANGE: findPeer returns id and addrs properties instead of peer-info instance

Needs:

- [x]  [libp2p/js-libp2p-interfaces#43](https://github.com/libp2p/js-libp2p-interfaces/pull/43)