### PR TITLE
chore: make ipfs-http-client a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Requires access to `/api/v0/dht/findpeer` HTTP API endpoint of the delegate node
 
 [Jacob Heun](https://github.com/jacobheun)
 
+## Requirements
+
+`libp2p-delegated-peer-routing` leverages the `ipfs-http-client` library and requires it as a peer dependency, as such, both must be installed in order for this module to work properly.
+
+```sh
+npm install ipfs-http-client libp2p-delegated-peer-routing
+```
+
 ## Example
 
 ```js

--- a/package.json
+++ b/package.json
@@ -23,11 +23,14 @@
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "0.4.23-3",
     "ipfs-utils": "^2.2.0",
+    "ipfs-http-client": "^44.0.0",
     "ipfsd-ctl": "^4.0.1"
+  },
+  "peerDependencies": {
+    "ipfs-http-client": "^44.0.0"
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "ipfs-http-client": "^44.0.0",
     "p-queue": "^6.3.0",
     "peer-id": "^0.13.11"
   },


### PR DESCRIPTION
BREAKING CHANGE: The ipfs-http-client must now be installed
as a peer dependency. It is no longer included as a dependency
of this module.

The reason the http-client should be a peerDependency and
not a dependency is that its API requires knowledge of the
http-client (we pass in the api endpoint details).

supersedes #24 