### PR TITLE
feat: add support for api dht/query endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,12 @@
     "ipfs-http-client": "^44.0.0"
   },
   "dependencies": {
+    "cids": "^1.0.0",
     "debug": "^4.1.1",
+    "p-defer": "^3.0.0",
     "p-queue": "^6.3.0",
-    "peer-id": "^0.14.0"
+    "peer-id": "^0.14.0",
+    "uint8arrays": "^1.1.0"
   },
   "contributors": [
     "Jacob Heun <jacobheun@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "debug": "^4.1.1",
     "p-defer": "^3.0.0",
     "p-queue": "^6.3.0",
-    "peer-id": "^0.14.0",
-    "uint8arrays": "^1.1.0"
+    "peer-id": "^0.14.0"
   },
   "contributors": [
     "Jacob Heun <jacobheun@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "go-ipfs": "0.6.0",
     "ipfs-http-client": "^45.0.0",
     "ipfs-utils": "^2.2.0",
-    "ipfsd-ctl": "^5.0.0"
+    "ipfsd-ctl": "^5.0.0",
+    "it-all": "^1.0.2"
   },
   "peerDependencies": {
     "ipfs-http-client": "^44.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ class DelegatedPeerRouting {
     key = new CID(key)
     const keyStr = key.toString()
 
-    log('query starts:', keyStr)
+    log('getClosestPeers starts:', keyStr)
     options.timeout = options.timeout || DEFAULT_TIMEOUT
 
     const onStart = defer()
@@ -122,15 +122,15 @@ class DelegatedPeerRouting {
             }
             break
           default:
-            log('unhandled response', result)
+            log('getClosestPeers unhandled response', result)
         }
       }
     } catch (err) {
-      log.error('findProviders errored:', err)
+      log.error('getClosestPeers errored:', err)
       throw err
     } finally {
       onFinish.resolve()
-      log('findProviders finished:', keyStr)
+      log('getClosestPeers finished:', keyStr)
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,10 @@
 
 const PeerId = require('peer-id')
 const createFindPeer = require('ipfs-http-client/src/dht/find-peer')
+const createQuery = require('ipfs-http-client/src/dht/query')
+const CID = require('cids')
 const { default: PQueue } = require('p-queue')
+const defer = require('p-defer')
 const debug = require('debug')
 
 const log = debug('libp2p-delegated-peer-routing')
@@ -19,7 +22,10 @@ const CONCURRENT_HTTP_REQUESTS = 4
 class DelegatedPeerRouting {
   constructor (api) {
     this.api = Object.assign({}, DEFAULT_IPFS_API, api)
-    this.dht = { findPeer: createFindPeer(this.api) }
+    this.dht = {
+      findPeer: createFindPeer(this.api),
+      getClosestPeers: createQuery(this.api)
+    }
 
     // limit concurrency to avoid request flood in web browser
     // https://github.com/libp2p/js-libp2p-delegated-content-routing/issues/12
@@ -66,6 +72,65 @@ class DelegatedPeerRouting {
       throw err
     } finally {
       log('findPeer finished: ' + id)
+    }
+  }
+
+  /**
+   * Attempt to find the closest peers on the network to the given key
+   * @param {Uint8Array} key A CID like key
+   * @param {object} options
+   * @param {number} options.timeout How long the query can take. Defaults to 30 seconds
+   * @returns {AsyncIterable<{ id: PeerId, multiaddrs: Multiaddr[] }>}
+   */
+  async * getClosestPeers (key, options = {}) {
+    key = new CID(key)
+    const keyStr = key.toString()
+
+    log('query starts:', keyStr)
+    options.timeout = options.timeout || DEFAULT_TIMEOUT
+
+    const onStart = defer()
+    const onFinish = defer()
+
+    this._httpQueue.add(() => {
+      onStart.resolve()
+      return onFinish.promise
+    })
+
+    try {
+      await onStart.promise
+
+      const peers = new Map()
+
+      for await (const result of this.dht.getClosestPeers(keyStr, {
+        timeout: options.timeout
+      })) {
+        switch (result.type) {
+          case 1: // Found Closer
+            // Track the addresses, so we can yield them when done
+            result.responses.forEach(response => {
+              peers.set(response.id, {
+                id: PeerId.createFromCID(result.id),
+                multiaddrs: response.addrs
+              })
+            })
+            break
+          case 2: // Final Peer
+            yield peers.get(result.id.string) || {
+              id: PeerId.createFromCID(result.id),
+              multiaddrs: []
+            }
+            break
+          default:
+            log('unhandled response', result)
+        }
+      }
+    } catch (err) {
+      log.error('findProviders errored:', err)
+      throw err
+    } finally {
+      onFinish.resolve()
+      log('findProviders finished:', keyStr)
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -78,8 +78,8 @@ class DelegatedPeerRouting {
   /**
    * Attempt to find the closest peers on the network to the given key
    * @param {Uint8Array} key A CID like key
-   * @param {object} options
-   * @param {number} options.timeout How long the query can take. Defaults to 30 seconds
+   * @param {object} [options]
+   * @param {number} [options.timeout=30e3] How long the query can take.
    * @returns {AsyncIterable<{ id: PeerId, multiaddrs: Multiaddr[] }>}
    */
   async * getClosestPeers (key, options = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ class DelegatedPeerRouting {
             // Track the addresses, so we can yield them when done
             result.responses.forEach(response => {
               peers.set(response.id, {
-                id: PeerId.createFromCID(result.id),
+                id: PeerId.createFromCID(response.id),
                 multiaddrs: response.addrs
               })
             })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -166,4 +166,44 @@ describe('DelegatedPeerRouting', function () {
       expect(peer).to.not.exist()
     })
   })
+
+  describe('query', () => {
+    it('should be able to query for the closest peers', async () => {
+      const opts = delegatedNode.apiAddr.toOptions()
+
+      const router = new DelegatedPeerRouting({
+        protocol: 'http',
+        port: opts.port,
+        host: opts.host
+      })
+
+      const results = []
+      for await (const result of router.getClosestPeers(PeerID.createFromB58String(peerIdToFind.id).id)) {
+        results.push(result)
+      }
+
+      // we should be closest to the 2 other peers
+      expect(results.length).to.equal(2)
+    })
+
+    it('should find closest peers even if the peer doesnt exist', async () => {
+      const opts = delegatedNode.apiAddr.toOptions()
+
+      const router = new DelegatedPeerRouting({
+        protocol: 'http',
+        port: opts.port,
+        host: opts.host
+      })
+
+      const peerId = await PeerID.create({ keyType: 'ed25519' })
+
+      const results = []
+      for await (const result of router.getClosestPeers(peerId.id)) {
+        results.push(result)
+      }
+
+      // we should be closest to the 2 other peers
+      expect(results.length).to.equal(2)
+    })
+  })
 })


### PR DESCRIPTION
This adds support for the dht/query endpoint of IPFS. For peer routing the dht/query endpoint is equivalent to `getClosestPeers`, https://github.com/libp2p/js-libp2p-kad-dht/blob/v0.20.1/src/index.js#L304, which this matches.

The public delegate nodes already have support enabled for this endpoint.

fixes https://github.com/libp2p/js-libp2p-delegated-peer-routing/issues/36