### PR TITLE
fix: accept http client instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ stages:
   - cov
 
 node_js:
-  - '10'
-  - '12'
+  - 'lts/*'
+  - 'node'
 
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requires access to `/api/v0/dht/findpeer` HTTP API endpoint of the delegate node
 
 ## Requirements
 
-`libp2p-delegated-peer-routing` leverages the `ipfs-http-client` library and requires it as a peer dependency, as such, both must be installed in order for this module to work properly.
+`libp2p-delegated-peer-routing` leverages the `ipfs-http-client` library and requires an instance of it as a constructor argument.
 
 ```sh
 npm install ipfs-http-client libp2p-delegated-peer-routing
@@ -20,9 +20,15 @@ npm install ipfs-http-client libp2p-delegated-peer-routing
 
 ```js
 const DelegatedPeerRouting = require('libp2p-delegated-peer-routing')
+const ipfsHttpClient = require('ipfs-http-client')
 
 // default is to use ipfs.io
-const routing = new DelegatedPeerRouing()
+const routing = new DelegatedPeerRouing(ipfsHttpClient{
+  // use default api settings
+  protocol: 'https',
+  port: 443,
+  host: 'node0.delegate.ipfs.io'
+})
 
 try {
   const { id, multiaddrs } = await routing.findPeer('peerid')

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ const DelegatedPeerRouting = require('libp2p-delegated-peer-routing')
 const ipfsHttpClient = require('ipfs-http-client')
 
 // default is to use ipfs.io
-const routing = new DelegatedPeerRouing(ipfsHttpClient{
+const routing = new DelegatedPeerRouing(ipfsHttpClient({
   // use default api settings
   protocol: 'https',
   port: 443,
   host: 'node0.delegate.ipfs.io'
-})
+}))
 
 try {
   const { id, multiaddrs } = await routing.findPeer('peerid')

--- a/package.json
+++ b/package.json
@@ -22,15 +22,12 @@
     "coverage": "aegir coverage"
   },
   "devDependencies": {
-    "aegir": "^25.0.0",
+    "aegir": "^26.0.0",
     "go-ipfs": "0.6.0",
-    "ipfs-http-client": "^45.0.0",
-    "ipfs-utils": "^2.2.0",
-    "ipfsd-ctl": "^5.0.0",
+    "ipfs-http-client": "^46.0.0",
+    "ipfs-utils": "^3.0.0",
+    "ipfsd-ctl": "^7.0.0",
     "it-all": "^1.0.2"
-  },
-  "peerDependencies": {
-    "ipfs-http-client": "^44.0.0"
   },
   "dependencies": {
     "cids": "^1.0.0",
@@ -38,6 +35,9 @@
     "p-defer": "^3.0.0",
     "p-queue": "^6.3.0",
     "peer-id": "^0.14.0"
+  },
+  "browser": {
+    "go-ipfs": false
   },
   "contributors": [
     "Jacob Heun <jacobheun@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "p-queue": "^6.3.0",
     "peer-id": "^0.14.0"
   },
+  "peerDependencies": {
+    "ipfs-http-client": "^46.0.0"
+  },
   "browser": {
     "go-ipfs": false
   },

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,10 @@ const CONCURRENT_HTTP_REQUESTS = 4
 
 class DelegatedPeerRouting {
   constructor (client) {
+    if (client == null) {
+      throw new Error('missing ipfs http client')
+    }
+
     this._client = client
 
     // limit concurrency to avoid request flood in web browser
@@ -23,9 +27,9 @@ class DelegatedPeerRouting {
     })
 
     const {
+      protocol,
       host,
-      port,
-      protocol
+      port
     } = client.getEndpointConfig()
 
     log(`enabled DelegatedPeerRouting via ${protocol}://${host}:${port}`)

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
 'use strict'
 
 const PeerId = require('peer-id')
-const createFindPeer = require('ipfs-http-client/src/dht/find-peer')
-const createQuery = require('ipfs-http-client/src/dht/query')
 const CID = require('cids')
 const { default: PQueue } = require('p-queue')
 const defer = require('p-defer')
@@ -12,27 +10,25 @@ const log = debug('libp2p-delegated-peer-routing')
 log.error = debug('libp2p-delegated-peer-routing:error')
 
 const DEFAULT_TIMEOUT = 30e3 // 30 second default
-const DEFAULT_IPFS_API = {
-  protocol: 'https',
-  port: 443,
-  host: 'node0.delegate.ipfs.io'
-}
 const CONCURRENT_HTTP_REQUESTS = 4
 
 class DelegatedPeerRouting {
-  constructor (api) {
-    this.api = Object.assign({}, DEFAULT_IPFS_API, api)
-    this.dht = {
-      findPeer: createFindPeer(this.api),
-      getClosestPeers: createQuery(this.api)
-    }
+  constructor (client) {
+    this._client = client
 
     // limit concurrency to avoid request flood in web browser
     // https://github.com/libp2p/js-libp2p-delegated-content-routing/issues/12
     this._httpQueue = new PQueue({
       concurrency: CONCURRENT_HTTP_REQUESTS
     })
-    log(`enabled DelegatedPeerRouting via ${this.api.protocol}://${this.api.host}:${this.api.port}`)
+
+    const {
+      host,
+      port,
+      protocol
+    } = client.getEndpointConfig()
+
+    log(`enabled DelegatedPeerRouting via ${protocol}://${host}:${port}`)
   }
 
   /**
@@ -55,7 +51,7 @@ class DelegatedPeerRouting {
 
     try {
       return await this._httpQueue.add(async () => {
-        const { addrs } = await this.dht.findPeer(idStr, {
+        const { addrs } = await this._client.dht.findPeer(idStr, {
           timeout: options.timeout
         })
 
@@ -102,7 +98,7 @@ class DelegatedPeerRouting {
 
       const peers = new Map()
 
-      for await (const result of this.dht.getClosestPeers(keyStr, {
+      for await (const result of this._client.dht.query(keyStr, {
         timeout: options.timeout
       })) {
         switch (result.type) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,6 +6,7 @@ const { createFactory } = require('ipfsd-ctl')
 const PeerID = require('peer-id')
 const { isNode } = require('ipfs-utils/src/env')
 const concat = require('it-all')
+const ipfsHttpClient = require('ipfs-http-client')
 
 const DelegatedPeerRouting = require('../src')
 const factory = createFactory({
@@ -72,38 +73,23 @@ describe('DelegatedPeerRouting', function () {
   })
 
   describe('create', () => {
-    it('should default to https://node0.delegate.ipfs.io as the delegate', () => {
-      const router = new DelegatedPeerRouting()
-
-      expect(router.api).to.include({
-        protocol: 'https',
-        port: 443,
-        host: 'node0.delegate.ipfs.io'
-      })
-    })
-
-    it('should allow for just specifying the host', () => {
-      const router = new DelegatedPeerRouting({
-        host: 'other.ipfs.io'
-      })
-
-      expect(router.api).to.include({
-        protocol: 'https',
-        port: 443,
-        host: 'other.ipfs.io'
-      })
-    })
-
-    it('should allow for overriding the api', () => {
-      const api = {
-        apiPath: '/api/v1',
+    it('should accept an http api client instance', () => {
+      const client = ipfsHttpClient({
         protocol: 'http',
         port: 8000,
         host: 'localhost'
-      }
-      const router = new DelegatedPeerRouting(api)
+      })
+      const router = new DelegatedPeerRouting(client)
 
-      expect(router.api).to.include(api)
+      expect(router).to.have.property('_client')
+        .that.has.property('getEndpointConfig')
+        .that.is.a('function')
+
+      expect(router._client.getEndpointConfig()).to.deep.include({
+        protocol: 'http:',
+        port: '8000',
+        host: 'localhost'
+      })
     })
   })
 
@@ -111,11 +97,11 @@ describe('DelegatedPeerRouting', function () {
     it('should be able to find peers via the delegate with a peer id string', async () => {
       const opts = delegatedNode.apiAddr.toOptions()
 
-      const router = new DelegatedPeerRouting({
+      const router = new DelegatedPeerRouting(ipfsHttpClient({
         protocol: 'http',
         port: opts.port,
         host: opts.host
-      })
+      }))
 
       const { id, multiaddrs } = await router.findPeer(peerIdToFind.id)
       expect(id).to.exist()
@@ -125,11 +111,11 @@ describe('DelegatedPeerRouting', function () {
 
     it('should be able to find peers via the delegate with a peerid', async () => {
       const opts = delegatedNode.apiAddr.toOptions()
-      const router = new DelegatedPeerRouting({
+      const router = new DelegatedPeerRouting(ipfsHttpClient({
         protocol: 'http',
         port: opts.port,
         host: opts.host
-      })
+      }))
 
       const { id, multiaddrs } = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id))
       expect(id).to.exist()
@@ -140,11 +126,11 @@ describe('DelegatedPeerRouting', function () {
 
     it('should be able to specify a timeout', async () => {
       const opts = delegatedNode.apiAddr.toOptions()
-      const router = new DelegatedPeerRouting({
+      const router = new DelegatedPeerRouting(ipfsHttpClient({
         protocol: 'http',
         port: opts.port,
         host: opts.host
-      })
+      }))
 
       const { id, multiaddrs } = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id), { timeout: 2000 })
       expect(id).to.exist()
@@ -155,11 +141,11 @@ describe('DelegatedPeerRouting', function () {
 
     it('should not be able to find peers not on the network', async () => {
       const opts = delegatedNode.apiAddr.toOptions()
-      const router = new DelegatedPeerRouting({
+      const router = new DelegatedPeerRouting(ipfsHttpClient({
         protocol: 'http',
         port: opts.port,
         host: opts.host
-      })
+      }))
 
       // This is one of the default Bootstrap nodes, but we're not connected to it
       // so we'll test with it.
@@ -172,11 +158,11 @@ describe('DelegatedPeerRouting', function () {
     it('should be able to query for the closest peers', async () => {
       const opts = delegatedNode.apiAddr.toOptions()
 
-      const router = new DelegatedPeerRouting({
+      const router = new DelegatedPeerRouting(ipfsHttpClient({
         protocol: 'http',
         port: opts.port,
         host: opts.host
-      })
+      }))
 
       const nodeId = await delegatedNode.api.id()
       const delegatePeerId = PeerID.createFromCID(nodeId.id)
@@ -196,11 +182,11 @@ describe('DelegatedPeerRouting', function () {
     it('should find closest peers even if the peer doesnt exist', async () => {
       const opts = delegatedNode.apiAddr.toOptions()
 
-      const router = new DelegatedPeerRouting({
+      const router = new DelegatedPeerRouting(ipfsHttpClient({
         protocol: 'http',
         port: opts.port,
         host: opts.host
-      })
+      }))
 
       const nodeId = await delegatedNode.api.id()
       const delegatePeerId = PeerID.createFromCID(nodeId.id)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -73,7 +73,11 @@ describe('DelegatedPeerRouting', function () {
   })
 
   describe('create', () => {
-    it('should accept an http api client instance', () => {
+    it('should require an http api client instance at construction time', () => {
+      expect(() => new DelegatedPeerRouting()).to.throw()
+    })
+
+    it('should accept an http api client instance at construction time', () => {
       const client = ipfsHttpClient({
         protocol: 'http',
         port: 8000,


### PR DESCRIPTION
Instead of the http client being a dependency of this module, accept
a pre-configured http client instance at construction time.

This resolves the weird dependency loop and means we can remove this
module from the no-hoist config in ipfs.

BREAKING CHANGE:

- An instance of ipfs http client is now a required argument