### PR TITLE
chore: update ipfs-http-client peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "coverage": "aegir coverage"
   },
   "devDependencies": {
-    "aegir": "^26.0.0",
-    "go-ipfs": "0.6.0",
+    "aegir": "^28.0.2",
+    "go-ipfs": "^0.7.0",
     "ipfs-http-client": "^47.0.1",
-    "ipfs-utils": "^3.0.0",
+    "ipfs-utils": "^4.0.0",
     "ipfsd-ctl": "^7.0.0",
     "it-all": "^1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "aegir": "^28.0.2",
+    "delay": "^4.4.0",
     "go-ipfs": "^0.7.0",
     "ipfs-http-client": "^47.0.1",
     "ipfs-utils": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "go-ipfs": "^0.7.0",
     "ipfs-http-client": "^47.0.1",
     "ipfs-utils": "^4.0.0",
-    "ipfsd-ctl": "ipfs/js-ipfsd-ctl#fix/guard-on-null-subprocess",
+    "ipfsd-ctl": "^7.0.0",
     "it-all": "^1.0.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,11 +23,10 @@
   },
   "devDependencies": {
     "aegir": "^28.0.2",
-    "delay": "^4.4.0",
     "go-ipfs": "^0.7.0",
     "ipfs-http-client": "^47.0.1",
     "ipfs-utils": "^4.0.0",
-    "ipfsd-ctl": "^7.0.0",
+    "ipfsd-ctl": "ipfs/js-ipfsd-ctl#fix/guard-on-null-subprocess",
     "it-all": "^1.0.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "aegir": "^26.0.0",
     "go-ipfs": "0.6.0",
-    "ipfs-http-client": "^46.0.0",
+    "ipfs-http-client": "^47.0.1",
     "ipfs-utils": "^3.0.0",
     "ipfsd-ctl": "^7.0.0",
     "it-all": "^1.0.2"
@@ -37,7 +37,7 @@
     "peer-id": "^0.14.0"
   },
   "peerDependencies": {
-    "ipfs-http-client": "^46.0.0"
+    "ipfs-http-client": "^47.0.1"
   },
   "browser": {
     "go-ipfs": false

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ class DelegatedPeerRouting {
    *
    * @param {PeerID} id
    * @param {object} options
-   * @param {number} options.timeout How long the query can take. Defaults to 30 seconds
+   * @param {number} options.timeout - How long the query can take. Defaults to 30 seconds
    * @returns {Promise<{ id: PeerId, multiaddrs: Multiaddr[] }>}
    */
   async findPeer (id, options = {}) {
@@ -82,9 +82,10 @@ class DelegatedPeerRouting {
 
   /**
    * Attempt to find the closest peers on the network to the given key
-   * @param {Uint8Array} key A CID like key
+   *
+   * @param {Uint8Array} key - A CID like key
    * @param {object} [options]
-   * @param {number} [options.timeout=30e3] How long the query can take.
+   * @param {number} [options.timeout=30e3] - How long the query can take.
    * @returns {AsyncIterable<{ id: PeerId, multiaddrs: Multiaddr[] }>}
    */
   async * getClosestPeers (key, options = {}) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -107,7 +107,10 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       }))
 
-      const { id, multiaddrs } = await router.findPeer(peerIdToFind.id)
+      const peer = await router.findPeer(peerIdToFind.id)
+      expect(peer).to.be.ok()
+
+      const { id, multiaddrs } = peer
       expect(id).to.exist()
       expect(multiaddrs).to.exist()
       expect(id).to.eql(peerIdToFind.id)
@@ -121,7 +124,10 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       }))
 
-      const { id, multiaddrs } = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id))
+      const peer = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id))
+      expect(peer).to.be.ok()
+
+      const { id, multiaddrs } = peer
       expect(id).to.exist()
       expect(multiaddrs).to.exist()
 
@@ -136,7 +142,10 @@ describe('DelegatedPeerRouting', function () {
         host: opts.host
       }))
 
-      const { id, multiaddrs } = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id), { timeout: 2000 })
+      const peer = await router.findPeer(PeerID.createFromB58String(peerIdToFind.id), { timeout: 2000 })
+      expect(peer).to.be.ok()
+
+      const { id, multiaddrs } = peer
       expect(id).to.exist()
       expect(multiaddrs).to.exist()
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -7,7 +7,6 @@ const PeerID = require('peer-id')
 const { isNode } = require('ipfs-utils/src/env')
 const concat = require('it-all')
 const ipfsHttpClient = require('ipfs-http-client')
-const delay = require('delay')
 
 const DelegatedPeerRouting = require('../src')
 const factory = createFactory({
@@ -36,18 +35,6 @@ async function spawnNode (boostrap = []) {
   }
 }
 
-async function waitForPeer (ipfs, remote) {
-  for (let i = 0; i < 5; i++) {
-    const peers = await ipfs.swarm.peers()
-
-    if (peers.find(({ peer }) => peer === remote.id)) {
-      return
-    }
-
-    await delay(1000)
-  }
-}
-
 describe('DelegatedPeerRouting', function () {
   this.timeout(20 * 1000) // we're spawning daemons, give ci some time
 
@@ -68,15 +55,9 @@ describe('DelegatedPeerRouting', function () {
     nodeToFind = local.node
     peerIdToFind = local.id
 
-    await waitForPeer(local.node.api, bootstrap.id)
-    await waitForPeer(bootstrap.node.api, local.id)
-
     // Spawn the delegate node and bootstrap the bootstrapper node
     const delegate = await spawnNode(bootstrapId.addresses)
     delegatedNode = delegate.node
-
-    await waitForPeer(delegate.node.api, bootstrap.id)
-    await waitForPeer(bootstrap.node.api, delegate.id)
   })
 
   after(() => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -18,12 +18,12 @@ const factory = createFactory({
   endpoint: 'http://localhost:57483'
 })
 
-async function spawnNode (boostrap = []) {
+async function spawnNode (bootstrap = []) {
   const node = await factory.spawn({
     // Lock down the nodes so testing can be deterministic
     ipfsOptions: {
       config: {
-        Bootstrap: boostrap
+        Bootstrap: bootstrap
       }
     }
   })


### PR DESCRIPTION
Fixes this sort of error:

```
npm ERR! Conflicting peer dependency: ipfs-http-client@46.1.2
npm ERR! node_modules/ipfs-http-client
npm ERR!   peer ipfs-http-client@"^46.0.0" from libp2p-delegated-peer-routing@0.7.0
npm ERR!   node_modules/libp2p-delegated-peer-routing
npm ERR!     libp2p-delegated-peer-routing@"^0.7.0" from the root project
```