### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "coverage": "aegir coverage"
   },
   "devDependencies": {
-    "aegir": "^28.0.2",
+    "aegir": "^29.1.0",
     "go-ipfs": "^0.7.0",
-    "ipfs-http-client": "^47.0.1",
-    "ipfs-utils": "^4.0.0",
+    "ipfs-http-client": "^48.1.2",
+    "ipfs-utils": "^5.0.1",
     "ipfsd-ctl": "^7.0.0",
     "it-all": "^1.0.2"
   },
@@ -37,7 +37,7 @@
     "peer-id": "^0.14.0"
   },
   "peerDependencies": {
-    "ipfs-http-client": "^47.0.1"
+    "ipfs-http-client": "*"
   },
   "browser": {
     "go-ipfs": false


### PR DESCRIPTION
npm 7 now errors when peer dependencies aren't satisfied, so we need to keep the `ipfs-http-client` peer dep in this module up to date:

```console
$ npm install 
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! Found: ipfs-http-client@48.1.2
npm ERR! node_modules/ipfs-http-client
npm ERR!   dev ipfs-http-client@"^48.1.2" from the root project
npm ERR!   peer ipfs-http-client@"*" from ipfsd-ctl@7.0.0
npm ERR!   node_modules/ipfsd-ctl
npm ERR!     dev ipfsd-ctl@"^7.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer ipfs-http-client@"^46.0.0" from libp2p-delegated-content-routing@0.7.0
npm ERR! node_modules/libp2p-delegated-content-routing
npm ERR!   libp2p-delegated-content-routing@"^0.7.0" from ipfs@0.50.2
npm ERR!   node_modules/ipfs
npm ERR!     peer ipfs@"*" from ipfsd-ctl@7.0.0
npm ERR!     node_modules/ipfsd-ctl
npm ERR!       dev ipfsd-ctl@"^7.0.0" from the root project
```