### PR TITLE
chore: remove peer deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ os:
   - linux
   - osx
 
+before_install:
+  # modules with pre-built binaries may not have deployed versions for bleeding-edge node so this lets us fall back to building from source
+  - npm install @mapbox/node-pre-gyp -g
+
 script: npx nyc -s npm run test:node -- --bail
 after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
 

--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "p-queue": "^6.3.0",
     "peer-id": "^0.14.0"
   },
-  "peerDependencies": {
-    "ipfs-http-client": "*"
-  },
   "browser": {
     "go-ipfs": false
   },


### PR DESCRIPTION
We added ipfs-http-client as a peer dep to signal to the user
that they should add the modules they depend on as deps of their project.

Starting with npm7 all peer deps get installed automatically which
defeats the purpose of our use of peer deps, so let's remove them.