### PR TITLE
fix: yield closer peers as they arrive

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-      # modules with pre-built binaries may not have deployed versions for bleeding-edge node so this lets us fall back to building from source
-      - run: npm install node-pre-gyp -g
       - run: npm install
       - run: npx nyc --reporter=lcov aegir test -t node -- --bail
       - uses: codecov/codecov-action@v1

--- a/src/index.js
+++ b/src/index.js
@@ -105,25 +105,16 @@ class DelegatedPeerRouting {
     try {
       await onStart.promise
 
-      const peers = new Map()
-
       for await (const result of this._client.dht.query(keyStr, {
         timeout: options.timeout
       })) {
         switch (result.type) {
           case 1: // Found Closer
-            // Track the addresses, so we can yield them when done
-            result.responses.forEach(response => {
-              peers.set(response.id, {
+            for (const response of result.responses) {
+              yield {
                 id: PeerId.parse(response.id),
                 multiaddrs: response.addrs
-              })
-            })
-            break
-          case 2: // Final Peer
-            yield peers.get(result.id.string) || {
-              id: PeerId.parse(result.id),
-              multiaddrs: []
+              }
             }
             break
           default:


### PR DESCRIPTION
The updated DHT client yields results as they become available so the delegate needs to do the same.

Also, they have addresses now.