### PR TITLE
fix!: remove @libp2p/components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # @libp2p/delegated-peer-routing <!-- omit in toc -->
 
 [![libp2p.io](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
-[![IRC](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 [![Discuss](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg?style=flat-square)](https://discuss.libp2p.io)
 [![codecov](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-delegated-peer-routing.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-delegated-peer-routing)
-[![CI](https://img.shields.io/github/workflow/status/libp2p/js-libp2p-interfaces/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/libp2p/js-libp2p-delegated-peer-routing/actions/workflows/js-test-and-release.yml)
+[![CI](https://img.shields.io/github/workflow/status/libp2p/js-libp2p-delegated-peer-routing/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/libp2p/js-libp2p-delegated-peer-routing/actions/workflows/js-test-and-release.yml)
 
 > Leverage other peers in the libp2p network to perform Peer Routing calls.
 
@@ -37,30 +36,28 @@ npm install ipfs-http-client libp2p-delegated-peer-routing
 ## Example
 
 ```js
-import { createEd25519PeerId } from '@libp2p/peer-id-factory'
-import { DelegatedPeerRouting } from '@libp2p/delegated-peer-routing')
+import { createLibp2p } from 'libp2p'
+import { delegatedPeerRouting } from '@libp2p/delegated-peer-routing')
 import { create as createIpfsHttpClient } from 'ipfs-http-client')
 
 // default is to use ipfs.io
-const routing = new DelegatedPeerRouting(createIpfsHttpClient({
+const client = createIpfsHttpClient({
   // use default api settings
   protocol: 'https',
   port: 443,
   host: 'node0.delegate.ipfs.io'
-}))
+})
 
-try {
-  for await (const event of routing.findPeer('peerid')) {
-    console.log('query event', event)
-  }
-} catch (err) {
-  console.error(err)
-}
+const node = await createLibp2p({
+  peerRouting: [
+    delegatedPeerRouting(client)
+  ]
+  //.. other config
+})
+await node.start()
 
-const peerId = await createEd25519PeerId()
-for await (const event of routing.getClosestPeers(peerId.id)) {
-  console.log('query event', event)
-}
+const peerInfo = await node.peerRouting.findPeer('peerid')
+console.log('peerInfo', peerInfo)
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@libp2p/peer-id": "^1.1.11",
     "any-signal": "^3.0.1",
     "err-code": "^3.0.1",
-    "multiformats": "^9.6.3",
+    "multiformats": "^10.0.0",
     "p-defer": "^4.0.0",
     "p-queue": "^7.2.0"
   },
@@ -155,7 +155,8 @@
     "ipfsd-ctl": "^12.0.2",
     "it-all": "^1.0.6",
     "it-drain": "^1.0.5",
-    "uint8arrays": "^3.0.0",
+    "timeout-abort-controller": "^3.0.0",
+    "uint8arrays": "^4.0.2",
     "wherearewe": "^2.0.1"
   },
   "browser": {


### PR DESCRIPTION
`@libp2p/components` is a choke-point for our dependency graph as it depends on every interface, meaning when one interface revs a major `@libp2p/components` major has to change too which means every module depending on it also needs a major.

Switch instead to constructor injection of simple objects that let modules declare their dependencies on interfaces directly instead of indirectly via `@libp2p/components`

Refs https://github.com/libp2p/js-libp2p-components/issues/6

BREAKING CHANGE: modules no longer implement `Initializable` instead switching to constructor injection