### PR TITLE
fix(debug-logs): use 'libp2p:' namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import type { PeerInfo } from '@libp2p/interface-peer-info'
 import type { Startable } from '@libp2p/interfaces/startable'
 import { peerIdFromBytes } from '@libp2p/peer-id'
 
-const log = logger('libp2p-delegated-peer-routing')
+const log = logger('libp2p:delegated-peer-routing')
 
 const DEFAULT_TIMEOUT = 30e3 // 30 second default
 const CONCURRENT_HTTP_REQUESTS = 4


### PR DESCRIPTION
should use "libp2p:" prefix, not "libp2p-"

![image](https://user-images.githubusercontent.com/1173416/226493433-e6e95b44-50b7-46f0-b0c9-deeeec5ed5e0.png)
