### PR TITLE
fix: replace err-code with CodeError

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@libp2p/interface-peer-id": "^2.0.0",
     "@libp2p/interface-peer-info": "^1.0.1",
     "@libp2p/interface-peer-routing": "^1.0.0",
-    "@libp2p/interfaces": "^3.0.2",
+    "@libp2p/interfaces": "^3.3.1",
     "@libp2p/logger": "^2.0.0",
     "@libp2p/peer-id": "^2.0.0",
     "any-signal": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "@libp2p/logger": "^2.0.0",
     "@libp2p/peer-id": "^2.0.0",
     "any-signal": "^3.0.1",
-    "err-code": "^3.0.1",
     "ipfs-core-types": "^0.14.0",
     "multiformats": "^11.0.0",
     "p-defer": "^4.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { logger } from '@libp2p/logger'
 import { CID } from 'multiformats/cid'
 import PQueue from 'p-queue'
 import defer from 'p-defer'
-import errCode from 'err-code'
+import { CodeError } from '@libp2p/interfaces/errors'
 import anySignal from 'any-signal'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { AbortOptions } from 'ipfs-core-types/src/utils'
@@ -202,7 +202,7 @@ class DelegatedPeerRouting implements PeerRouting, Startable {
       log('findPeer finished: %p', id)
     }
 
-    throw errCode(new Error('Not found'), 'ERR_NOT_FOUND')
+    throw new CodeError('Not found', 'ERR_NOT_FOUND')
   }
 
   /**


### PR DESCRIPTION
Related: https://github.com/libp2p/js-libp2p/issues/1269

- deps: bump @libp2p/interfaces
- fix: replace err-code with CodeError
- deps: remove err-code
