### PR TITLE
refactor: remove use of timeout-abort-controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "ipfsd-ctl": "^13.0.0",
     "it-all": "^3.0.1",
     "it-drain": "^2.0.0",
-    "timeout-abort-controller": "^3.0.0",
     "uint8arrays": "^4.0.2",
     "wherearewe": "^2.0.1"
   },

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -18,7 +18,6 @@ import { CID } from 'multiformats/cid'
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import { stop } from '@libp2p/interfaces/startable'
-import { TimeoutController } from 'timeout-abort-controller'
 
 const factory = createFactory({
   type: 'go',
@@ -179,17 +178,15 @@ describe('DelegatedPeerRouting', function () {
         port: opts.port,
         host: opts.host
       }))()
-      const controller = new TimeoutController(5e3)
+      const signal = AbortSignal.timeout(5e3)
 
-      const peer = await router.findPeer(peerIdToFind.id, { signal: controller.signal })
+      const peer = await router.findPeer(peerIdToFind.id, { signal })
 
       const { id, multiaddrs } = peer
       expect(id).to.exist()
       expect(multiaddrs).to.exist()
 
       expect(id.toString()).to.eql(peerIdToFind.id.toString())
-
-      controller.clear()
     })
 
     it('should not be able to find peers not on the network', async () => {


### PR DESCRIPTION
related https://github.com/libp2p/js-libp2p/issues/1681